### PR TITLE
Fix comments spelling in vip.py

### DIFF
--- a/vip.py
+++ b/vip.py
@@ -47,12 +47,12 @@ def ip_addr_manipulation(action, vip_address):
     index = ip.link_lookup(ifname=vm_interface)
     if index:
         try:
-            # Assing or remove IP address (vm_vip_address) to/from network interface (vm_interface)
+            # Assign or remove IP address (vm_vip_address) to/from network interface (vm_interface)
             ip.addr(action, index, vip_address, mask=24)
             if action == 'add':
                 logger.info("An ip address {} added to the network interface {}.".format(
                     vip_address, vm_interface))
-                # If assigend, send arp ping to everyone at Level2
+                # If assigned, send arp ping to everyone at Level2
                 sendp(Ether(dst='ff:ff:ff:ff:ff:ff')/ARP(psrc=vm_vip_address),iface=vm_interface,loop=1,inter=0,count=3)
             else:
                 logger.info("An ip address {} removed from the network interface {}.".format(


### PR DESCRIPTION
## Summary
- fix spelling in comments above `ip.addr` and `sendp`

## Testing
- `python -m py_compile vip.py`


------
https://chatgpt.com/codex/tasks/task_e_6841206c84e883339ab877649002a97f