### PR TITLE
Fix VIP assignment interface index

### DIFF
--- a/vip.py
+++ b/vip.py
@@ -48,7 +48,7 @@ def ip_addr_manipulation(action, vip_address):
     if index:
         try:
             # Assing or remove IP address (vm_vip_address) to/from network interface (vm_interface)
-            ip.addr(action, index, vip_address, mask=24)
+            ip.addr(action, index[0], vip_address, mask=24)
             if action == 'add':
                 logger.info("An ip address {} added to the network interface {}.".format(
                     vip_address, vm_interface))


### PR DESCRIPTION
## Summary
- use the first interface index returned by IPRoute

## Testing
- `python3 -m py_compile vip.py`

------
https://chatgpt.com/codex/tasks/task_e_68411fd2c2888333a8a1e6c419016d2c